### PR TITLE
chore: 移行後の後処理（一時ドメイン撤去・GSC確認タグ）

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,10 +6,8 @@ compatibility_flags = ["nodejs_compat"]
 workers_dev = true
 
 # 本番カスタムドメイン。Pages から移行済み(2026-06-19)。
-# new.success-salon.haton14.com は移行検証用に残置(安定後に削除予定)。
 routes = [
   { pattern = "success-salon.haton14.com", custom_domain = true },
-  { pattern = "new.success-salon.haton14.com", custom_domain = true },
 ]
 
 # ビルドは package.json の deploy script（pnpm run build && wrangler deploy）で行うため


### PR DESCRIPTION
本番移行(Pages→Worker)後の小修正をまとめたPR。

- 検証用カスタムドメイン `new.success-salon.haton14.com` を撤去（`wrangler.toml` / Worker側とも削除済み・デプロイ反映済み）
- Google Search Console 所有権確認用の `<meta name="google-site-verification">` を追加（URLプレフィックスプロパティのHTMLタグ確認用・本番反映済み）

本番ドメイン `success-salon.haton14.com` のみ残ります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)