### PR TITLE
chore: Google Search Console 所有権確認タグを追加

### DIFF
--- a/app/routes/_renderer.tsx
+++ b/app/routes/_renderer.tsx
@@ -45,6 +45,8 @@ export default jsxRenderer(({ children, title, description, noindex }) => {
       <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        {/* Google Search Console 所有権確認 */}
+        <meta name="google-site-verification" content="TtRbVO7jsn2DdRzSxQnM533kT8MvdO3uJPKjKwDo_EE" />
         <title>{pageTitle}</title>
         <meta name="description" content={pageDescription} />
         {/* 404等はインデックス対象外。存在しないURLへのcanonicalも出さない */}


### PR DESCRIPTION
Google Search Console の所有権確認(URLプレフィックスプロパティ `https://success-salon.haton14.com/` のHTMLタグ方式)用に `<meta name="google-site-verification">` を `app/routes/_renderer.tsx` の `<head>` へ追加。本番デプロイ反映済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)