### PR TITLE
fix: 下部「トップページに戻る」ボタンの配置バランスを調整

### DIFF
--- a/app/components/common/Layout.tsx
+++ b/app/components/common/Layout.tsx
@@ -6,7 +6,7 @@ import { Footer } from './Footer'
 import { Header } from './Header'
 
 const BackToHome: FC<{ position: 'top' | 'bottom' }> = ({ position }) => (
-  <div class={`container mx-auto px-4 text-left ${position === 'top' ? 'py-4' : 'pb-12'}`}>
+  <div class={`container mx-auto px-4 ${position === 'top' ? 'py-4 text-left' : 'py-12 text-center'}`}>
     <Button href="/" variant="secondary" size="lg">
       ← トップページに戻る
     </Button>


### PR DESCRIPTION
## 概要
各サブページ下部の「← トップページに戻る」ボタンの配置バランスを調整。

## 課題
`Layout.tsx` の `BackToHome` (position=bottom) が以下で不揃いに見えていた:
- 上下余白が非対称 (`pb-12` のみ・上余白0) → 直前の中央寄せ `CTA` セクションに密着
- 中央寄せCTAの直後に**左寄せ単独ボタン**が続き視線がズレる

## 変更
- 下部ボタン: `text-left pb-12` → `py-12 text-center`（上下対称＋中央寄せ）
- 上部ボタンは戻り導線（パンくず的）として `py-4 text-left` のまま維持

## 確認
- `pnpm lint` / `pnpm typecheck` / Layout テスト pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)