### PR TITLE
chore: Workers Logs / Traces を有効化

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -18,6 +18,13 @@ directory = "dist"
 binding = "ASSETS"
 not_found_handling = "none"
 
+# Workers Logs / Workers Traces（オブザーバビリティ）を有効化
+[observability]
+enabled = true
+
+[observability.traces]
+enabled = true
+
 # プレビュー環境（pnpm deploy:preview で使用）
 [env.preview]
 name = "beauty-salon-success-preview"


### PR DESCRIPTION
## 概要

Cloudflare の Observability(Workers Logs / Workers Traces)を**本番環境**で有効化します。

## 変更内容

`wrangler.toml` に以下を追加:

```toml
[observability]
enabled = true

[observability.traces]
enabled = true
```

## 補足

- 反映は次回 `pnpm run deploy` 時。
- Logs / Traces はデプロイ後に Cloudflare ダッシュボード(Workers & Pages → Observability)で確認可能。
- Traces は自動トレーシング(早期ベータ)。`compatibility_date` は現状 `2026-06-01` で要件を満たす。
- プレビュー環境には適用していません(named environment は設定を継承しないため)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)