### PR TITLE
feat: 臨時休業などのお知らせ機能を追加

### DIFF
--- a/app/components/common/Layout.tsx
+++ b/app/components/common/Layout.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'hono/jsx'
 import MobileMenu from '../../islands/MobileMenu'
+import NoticeBanner from '../../islands/NoticeBanner'
 import type { LayoutProps } from '../../types'
 import { Button } from './Button'
 import { Footer } from './Footer'
@@ -17,6 +18,7 @@ export const Layout: FC<LayoutProps> = ({ children, currentPage, showFullFooter 
   return (
     <>
       <MobileMenu />
+      <NoticeBanner />
       <Header currentPage={currentPage} />
       {currentPage && <BackToHome position="top" />}
       {children}

--- a/app/islands/NoticeBanner.test.tsx
+++ b/app/islands/NoticeBanner.test.tsx
@@ -1,0 +1,50 @@
+/** @jsxImportSource hono/jsx/dom */
+// @vitest-environment jsdom
+
+import { render } from 'hono/jsx/dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Notice } from '../types'
+import NoticeBanner from './NoticeBanner'
+
+const activeNotice: Notice = { message: '本日は臨時休業します', startAt: '', endAt: '', enabled: true }
+
+const mockFetchNotice = (notice: Notice | null) => {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ notice }),
+  }) as unknown as typeof fetch
+}
+
+const mountBanner = () => {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  render(<NoticeBanner />, container)
+  return container
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  document.body.innerHTML = ''
+})
+
+describe('NoticeBanner', () => {
+  it('お知らせがあればバナーを表示する', async () => {
+    mockFetchNotice(activeNotice)
+    const container = mountBanner()
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('本日は臨時休業します')
+    })
+    expect(container.querySelector('[role="alert"]')).not.toBeNull()
+  })
+
+  it('お知らせが無ければ何も描画しない', async () => {
+    mockFetchNotice(null)
+    const container = mountBanner()
+
+    await vi.waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalled()
+    })
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+  })
+})

--- a/app/islands/NoticeBanner.tsx
+++ b/app/islands/NoticeBanner.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'hono/jsx'
+import type { Notice } from '../types'
+
+/**
+ * お知らせバナー（臨時休業など）。
+ * マーケHTMLはエッジキャッシュされるため、サーバー埋め込みだと最大1時間古くなる。
+ * 緊急性を担保するためクライアントから /api/notice（no-store）を取得して表示する。
+ * お知らせが無い日は何も描画しないので、通常時のレイアウトには一切影響しない。
+ */
+export default function NoticeBanner() {
+  const [notice, setNotice] = useState<Notice | null>(null)
+
+  useEffect(() => {
+    let aborted = false
+    fetch('/api/notice')
+      .then((res) => (res.ok ? (res.json() as Promise<{ notice: Notice | null }>) : null))
+      .then((data) => {
+        const fetched = data?.notice
+        if (aborted || !fetched) return
+        setNotice(fetched)
+      })
+      .catch(() => {
+        // 取得失敗時はバナーを出さない（サイト本体の表示は妨げない）
+      })
+    return () => {
+      aborted = true
+    }
+  }, [])
+
+  if (!notice) return null
+
+  return (
+    <div role="alert" class="notice-banner bg-amber-100 border-b-2 border-amber-400 text-amber-900">
+      <div class="container mx-auto px-4 py-3 flex items-start gap-2.5">
+        <span aria-hidden="true" class="shrink-0 mt-px text-lg leading-none">
+          ⚠️
+        </span>
+        <p class="flex-1 text-sm sm:text-base font-semibold leading-relaxed whitespace-pre-line">{notice.message}</p>
+      </div>
+    </div>
+  )
+}

--- a/app/lib/notice.test.ts
+++ b/app/lib/notice.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import type { Notice } from '../types'
+import { getActiveNotice, isNoticeActive, toInputValue, toStoredIso } from './notice'
+
+const base: Notice = { message: 'テスト', startAt: '', endAt: '', enabled: true }
+
+describe('toStoredIso', () => {
+  it('datetime-local値にJSTオフセットと秒を付与する', () => {
+    expect(toStoredIso('2026-06-19T13:00')).toBe('2026-06-19T13:00:00+09:00')
+  })
+
+  it('空文字は空文字のまま（期間指定なし）', () => {
+    expect(toStoredIso('')).toBe('')
+  })
+})
+
+describe('toInputValue', () => {
+  it('保存ISOをdatetime-local用の値に戻す', () => {
+    expect(toInputValue('2026-06-19T13:00:00+09:00')).toBe('2026-06-19T13:00')
+  })
+
+  it('空文字は空文字', () => {
+    expect(toInputValue('')).toBe('')
+  })
+})
+
+describe('isNoticeActive', () => {
+  const now = new Date('2026-06-19T12:00:00+09:00')
+
+  it('有効・本文あり・期間指定なしなら表示対象', () => {
+    expect(isNoticeActive(base, now)).toBe(true)
+  })
+
+  it('enabled=false なら非表示', () => {
+    expect(isNoticeActive({ ...base, enabled: false }, now)).toBe(false)
+  })
+
+  it('本文が空白のみなら非表示', () => {
+    expect(isNoticeActive({ ...base, message: '   ' }, now)).toBe(false)
+  })
+
+  it('開始前は非表示', () => {
+    expect(isNoticeActive({ ...base, startAt: '2026-06-19T13:00:00+09:00' }, now)).toBe(false)
+  })
+
+  it('開始後は表示', () => {
+    expect(isNoticeActive({ ...base, startAt: '2026-06-19T11:00:00+09:00' }, now)).toBe(true)
+  })
+
+  it('終了後は非表示', () => {
+    expect(isNoticeActive({ ...base, endAt: '2026-06-19T11:00:00+09:00' }, now)).toBe(false)
+  })
+
+  it('JSTで指定した期間をUTCの現在時刻と正しく比較する（タイムゾーン回帰）', () => {
+    // 2026-06-19T03:30Z = 12:30 JST。開始12:00JST後・終了13:00JST前なので表示。
+    const utcNow = new Date('2026-06-19T03:30:00Z')
+    const notice: Notice = {
+      ...base,
+      startAt: toStoredIso('2026-06-19T12:00'),
+      endAt: toStoredIso('2026-06-19T13:00'),
+    }
+    expect(isNoticeActive(notice, utcNow)).toBe(true)
+  })
+
+  it('null は非表示', () => {
+    expect(isNoticeActive(null, now)).toBe(false)
+  })
+})
+
+describe('getActiveNotice', () => {
+  const makeKv = (value: Notice | null) => ({ get: async () => value }) as unknown as KVNamespace
+
+  it('KV未接続なら null', async () => {
+    expect(await getActiveNotice(undefined, new Date())).toBeNull()
+  })
+
+  it('表示対象のお知らせを返す', async () => {
+    const notice: Notice = { ...base }
+    expect(await getActiveNotice(makeKv(notice), new Date('2026-06-19T12:00:00+09:00'))).toEqual(notice)
+  })
+
+  it('期間外なら null を返す', async () => {
+    const notice: Notice = { ...base, endAt: '2020-01-01T00:00:00+09:00' }
+    expect(await getActiveNotice(makeKv(notice), new Date())).toBeNull()
+  })
+})

--- a/app/lib/notice.ts
+++ b/app/lib/notice.ts
@@ -1,0 +1,60 @@
+import type { Notice } from '../types'
+
+// KV 内のお知らせ保存キー。お知らせは1件運用なので固定キー。
+const NOTICE_KEY = 'current'
+
+// 美容室はJST運用。Workers ランタイムのTZはUTCのため、オフセットを明示して
+// 「入力した時刻（JSTの壁時計）」と「now（UTCの瞬間）」を正しく比較する。
+const JST_OFFSET = '+09:00'
+
+/**
+ * datetime-local の入力値（"2026-06-19T13:00" = JSTの壁時計）を、
+ * オフセット付きの一意なISO文字列（"2026-06-19T13:00:00+09:00"）に変換する。
+ * 空文字はそのまま空文字（＝期間指定なし）。
+ */
+export const toStoredIso = (inputValue: string): string => {
+  if (!inputValue) return ''
+  // 秒が無い "YYYY-MM-DDTHH:mm"（長さ16）には ":00" を補う
+  const withSeconds = inputValue.length === 16 ? `${inputValue}:00` : inputValue
+  return `${withSeconds}${JST_OFFSET}`
+}
+
+/**
+ * 保存済みISO文字列を datetime-local 用の値（"YYYY-MM-DDTHH:mm"）へ戻す。
+ * 先頭16文字がそのままJSTの壁時計表現になる。
+ */
+export const toInputValue = (stored: string): string => (stored ? stored.slice(0, 16) : '')
+
+/**
+ * 「今このお知らせを表示すべきか」を判定する。
+ * 有効フラグON・本文あり・（開始/終了が指定されていれば）期間内、を満たすこと。
+ */
+export const isNoticeActive = (notice: Notice | null, now: Date): notice is Notice => {
+  if (!notice?.enabled || !notice.message.trim()) return false
+  if (notice.startAt) {
+    const start = new Date(notice.startAt)
+    if (!Number.isNaN(start.getTime()) && now < start) return false
+  }
+  if (notice.endAt) {
+    const end = new Date(notice.endAt)
+    if (!Number.isNaN(end.getTime()) && now > end) return false
+  }
+  return true
+}
+
+/** KV から保存済みお知らせを読む（未設定・KV未接続なら null）。 */
+export const getStoredNotice = async (kv: KVNamespace | undefined): Promise<Notice | null> => {
+  if (!kv) return null
+  return await kv.get<Notice>(NOTICE_KEY, 'json')
+}
+
+/** KV にお知らせを保存する。 */
+export const saveStoredNotice = async (kv: KVNamespace, notice: Notice): Promise<void> => {
+  await kv.put(NOTICE_KEY, JSON.stringify(notice))
+}
+
+/** 公開向けに「今表示すべきお知らせ」を返す。表示対象が無ければ null。 */
+export const getActiveNotice = async (kv: KVNamespace | undefined, now: Date): Promise<Notice | null> => {
+  const notice = await getStoredNotice(kv)
+  return isNoticeActive(notice, now) ? notice : null
+}

--- a/app/routes/_middleware.ts
+++ b/app/routes/_middleware.ts
@@ -34,6 +34,11 @@ export default createRoute(
   // あるため s-maxage は短め、ブラウザは都度再検証(max-age=0)、配信はSWRで途切れさせない。
   async (c, next) => {
     await next()
+    // 管理画面（Access保護）は公開エッジキャッシュに載せない。
+    if (c.req.path.startsWith('/admin')) {
+      c.res.headers.set('Cache-Control', 'no-store')
+      return
+    }
     if (c.res.headers.get('content-type')?.includes('text/html')) {
       c.res.headers.set('Cache-Control', 'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400')
     }

--- a/app/routes/admin/index.test.tsx
+++ b/app/routes/admin/index.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { render } from '../../test-utils'
+import { AdminView } from './index'
+
+describe('お知らせ管理画面', () => {
+  it('保存フォームの主要な入力欄が表示される', () => {
+    const html = render(AdminView({ notice: null, saved: false, kvAvailable: true, userEmail: null }))
+
+    expect(html).toContain('お知らせ管理')
+    expect(html).toContain('method="post"')
+    expect(html).toContain('name="message"')
+    expect(html).toContain('name="startAt"')
+    expect(html).toContain('name="endAt"')
+    expect(html).toContain('name="enabled"')
+  })
+
+  it('既存のお知らせが初期値として埋め込まれる', () => {
+    const html = render(
+      AdminView({
+        notice: { message: 'こんにちは', startAt: '2026-06-19T13:00:00+09:00', endAt: '', enabled: true },
+        saved: false,
+        kvAvailable: true,
+        userEmail: 'owner@example.com',
+      })
+    )
+
+    expect(html).toContain('こんにちは')
+    expect(html).toContain('2026-06-19T13:00')
+    expect(html).toContain('owner@example.com')
+    expect(html).toContain('checked')
+  })
+
+  it('KV未接続なら警告が表示される', () => {
+    const html = render(AdminView({ notice: null, saved: false, kvAvailable: false, userEmail: null }))
+
+    expect(html).toContain('KV が接続されていません')
+  })
+
+  it('保存後はステータスメッセージが表示される', () => {
+    const html = render(AdminView({ notice: null, saved: true, kvAvailable: true, userEmail: null }))
+
+    expect(html).toContain('保存しました')
+  })
+})

--- a/app/routes/admin/index.tsx
+++ b/app/routes/admin/index.tsx
@@ -1,0 +1,132 @@
+import type { FC } from 'hono/jsx'
+import { createRoute } from 'honox/factory'
+import { getStoredNotice, saveStoredNotice, toInputValue, toStoredIso } from '../../lib/notice'
+import type { Bindings, Notice } from '../../types'
+
+type AdminViewProps = {
+  notice: Notice | null
+  saved: boolean
+  kvAvailable: boolean
+  userEmail: string | null
+}
+
+export const AdminView: FC<AdminViewProps> = ({ notice, saved, kvAvailable, userEmail }) => (
+  <main class="min-h-screen bg-gray-50 py-10">
+    <div class="container mx-auto px-4 max-w-2xl">
+      <div class="flex items-baseline justify-between mb-6">
+        <h1 class="text-2xl font-bold text-gray-800">お知らせ管理</h1>
+        {userEmail && <span class="text-sm text-gray-500">{userEmail}</span>}
+      </div>
+
+      {saved && (
+        <p role="status" class="mb-6 rounded-lg bg-green-50 border border-green-300 text-green-800 px-4 py-3">
+          保存しました。
+        </p>
+      )}
+
+      {!kvAvailable && (
+        <p role="alert" class="mb-6 rounded-lg bg-amber-50 border border-amber-300 text-amber-900 px-4 py-3 text-sm">
+          KV が接続されていません。ローカルの <code>pnpm dev</code> では保存できません。
+          <code>pnpm preview</code>（wrangler dev）またはデプロイ環境で操作してください。
+        </p>
+      )}
+
+      <form method="post" action="/admin" class="space-y-6 bg-white rounded-2xl shadow p-6">
+        <label class="flex items-center gap-3">
+          <input
+            type="checkbox"
+            name="enabled"
+            checked={notice?.enabled ?? false}
+            class="h-5 w-5 rounded border-gray-300"
+          />
+          <span class="font-medium text-gray-800">このお知らせを表示する</span>
+        </label>
+
+        <div>
+          <label for="message" class="block font-medium text-gray-800 mb-1">
+            本文
+          </label>
+          <textarea
+            id="message"
+            name="message"
+            rows={4}
+            required
+            placeholder="例: 都合により本日は臨時休業いたします。ご迷惑をおかけいたします。"
+            class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            {notice?.message ?? ''}
+          </textarea>
+          <p class="text-sm text-gray-500 mt-1">改行はそのまま表示されます。</p>
+        </div>
+
+        <div class="grid sm:grid-cols-2 gap-4">
+          <div>
+            <label for="startAt" class="block font-medium text-gray-800 mb-1">
+              表示開始
+            </label>
+            <input
+              type="datetime-local"
+              id="startAt"
+              name="startAt"
+              value={toInputValue(notice?.startAt ?? '')}
+              class="w-full rounded-lg border border-gray-300 px-3 py-2"
+            />
+            <p class="text-sm text-gray-500 mt-1">空欄なら即時に表示。</p>
+          </div>
+          <div>
+            <label for="endAt" class="block font-medium text-gray-800 mb-1">
+              表示終了
+            </label>
+            <input
+              type="datetime-local"
+              id="endAt"
+              name="endAt"
+              value={toInputValue(notice?.endAt ?? '')}
+              class="w-full rounded-lg border border-gray-300 px-3 py-2"
+            />
+            <p class="text-sm text-gray-500 mt-1">空欄なら手動でOFFにするまで表示。</p>
+          </div>
+        </div>
+
+        <button
+          type="submit"
+          class="w-full rounded-lg bg-blue-800 text-white font-bold py-3 hover:bg-blue-900 transition-colors"
+        >
+          保存する
+        </button>
+      </form>
+
+      <p class="text-sm text-gray-500 mt-4">
+        時刻は日本時間（JST）で指定してください。チェックを外すと即座に非表示になります。
+      </p>
+    </div>
+  </main>
+)
+
+// 管理画面（Cloudflare Access で特定の Google アカウントのみアクセス可）。
+export default createRoute(async (c) => {
+  const kv = (c.env as Bindings | undefined)?.NOTICE
+  const notice = await getStoredNotice(kv)
+  const userEmail = c.req.header('Cf-Access-Authenticated-User-Email') ?? null
+  return c.render(
+    <AdminView notice={notice} saved={c.req.query('saved') === '1'} kvAvailable={Boolean(kv)} userEmail={userEmail} />,
+    { title: 'お知らせ管理', noindex: true }
+  )
+})
+
+// お知らせの保存。
+export const POST = createRoute(async (c) => {
+  const kv = (c.env as Bindings | undefined)?.NOTICE
+  if (!kv) {
+    return c.text('KV が接続されていません。wrangler dev かデプロイ環境で操作してください。', 503)
+  }
+  const form = await c.req.formData()
+  const notice: Notice = {
+    message: String(form.get('message') ?? '').trim(),
+    startAt: toStoredIso(String(form.get('startAt') ?? '')),
+    endAt: toStoredIso(String(form.get('endAt') ?? '')),
+    enabled: form.get('enabled') === 'on',
+  }
+  await saveStoredNotice(kv, notice)
+  return c.redirect('/admin?saved=1')
+})

--- a/app/routes/api/notice.ts
+++ b/app/routes/api/notice.ts
@@ -1,0 +1,12 @@
+import { createRoute } from 'honox/factory'
+import { getActiveNotice } from '../../lib/notice'
+import type { Bindings } from '../../types'
+
+// 公開API: 今表示すべきお知らせを返す。
+// マーケHTMLはエッジで長くキャッシュするが、緊急のお知らせは常に最新である必要があるため
+// このエンドポイントは no-store にして、クライアントの NoticeBanner から都度取得する。
+export default createRoute(async (c) => {
+  const kv = (c.env as Bindings | undefined)?.NOTICE
+  const notice = await getActiveNotice(kv, new Date())
+  return c.json({ notice }, 200, { 'Cache-Control': 'no-store' })
+})

--- a/app/style.css
+++ b/app/style.css
@@ -82,3 +82,25 @@
     scroll-behavior: smooth;
   }
 }
+
+/* --------------------------------------------------------------------------
+   お知らせバナーの出現演出
+   --------------------------------------------------------------------------
+   臨時休業などのお知らせ出現時に、上から一度だけ静かにスライドインする。
+   点滅などの繰り返しアニメーションは行わない（しつこくならないよう配慮）。
+   prefers-reduced-motion: reduce では無効。
+   -------------------------------------------------------------------------- */
+@keyframes notice-slide-in {
+  from {
+    transform: translateY(-100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .notice-banner {
+    animation: notice-slide-in 0.35s ease-out;
+  }
+}

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -54,6 +54,19 @@ export type FAQItemType = {
   answer: string
 }
 
+// お知らせ（臨時休業など）。startAt/endAt は +09:00 オフセット付きISO文字列、または空文字。
+export type Notice = {
+  message: string
+  startAt: string
+  endAt: string
+  enabled: boolean
+}
+
+// Cloudflare Workers のバインディング（wrangler.toml と対応）
+export type Bindings = {
+  NOTICE: KVNamespace
+}
+
 // コンポーネント共通Props
 export type LayoutProps = {
   children: Child

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,12 +3,19 @@ main = "dist/_worker.js"
 compatibility_date = "2026-06-01"
 # honox の useRequestContext は AsyncLocalStorage(node:async_hooks) を使うため必須
 compatibility_flags = ["nodejs_compat"]
-workers_dev = true
+# 本番は workers.dev を無効化。Access で /admin を保護するのはカスタムドメインのみのため、
+# workers.dev 経由の素通り（Access バイパス）を塞ぐ。
+workers_dev = false
 
 # 本番カスタムドメイン。Pages から移行済み(2026-06-19)。
 routes = [
   { pattern = "success-salon.haton14.com", custom_domain = true },
 ]
+
+# お知らせ（臨時休業など）の保存先 KV。
+[[kv_namespaces]]
+binding = "NOTICE"
+id = "87b8ce65d1ec40dc8679d4a2a9b11509"
 
 # ビルドは package.json の deploy script（pnpm run build && wrangler deploy）で行うため
 # [build] は定義しない（定義すると wrangler がもう一度フルビルドして二重になる）
@@ -28,8 +35,19 @@ enabled = true
 # プレビュー環境（pnpm deploy:preview で使用）
 [env.preview]
 name = "beauty-salon-success-preview"
+# 本番の routes（カスタムドメイン）を継承しないよう明示的に空にする。
+# 継承するとプレビューのデプロイが本番ドメインを奪ってしまう。
+routes = []
+# プレビューはカスタムドメインを持たないため workers.dev で到達する。
+# 注意: プレビューの /admin は Access 未保護（検証用途）。本番のみが保護対象。
+workers_dev = true
 
 [env.preview.assets]
 directory = "dist"
 binding = "ASSETS"
 not_found_handling = "none"
+
+# プレビュー用 KV。
+[[env.preview.kv_namespaces]]
+binding = "NOTICE"
+id = "4f266f0c466142c0a439119a0ea30152"


### PR DESCRIPTION
## 概要
緊急の臨時休業などを掲示できる**お知らせバナー**と、特定の人だけが編集できる**管理画面**を追加しました。

## 機能
- **公開バナー**: サイト上部に表示。⚠️アイコン＋太字の落ち着いたデザイン（出現時に一度だけスライドイン、点滅なし）
- **表示期間**: 開始/終了（JST）を指定でき、期間外は自動で非表示。ON/OFFの手動切替も可能
- **管理画面 `/admin`**: 本文・期間・表示有無を編集して保存
- **認証**: Cloudflare Access で `/admin` を保護（許可したメールのみアクセス可）

## 設計上のポイント
- マーケHTMLはエッジで最大1時間キャッシュされるため、お知らせをサーバー埋め込みにすると緊急時に古いページが配信されてしまう。これを避けるため **NoticeBanner island が `/api/notice`（no-store）から取得** し、常に最新を保証。お知らせが無い日は何も描画せずレイアウト無影響
- **タイムゾーン**: Workers は UTC 稼働。入力（JSTの壁時計）を `+09:00` 付きで保存し、ズレなく比較（回帰テストあり）
- **セキュリティ**: workers.dev 経由の素通り（Accessバイパス）を防ぐため本番は `workers_dev = false`
- `env.preview` に `routes = []` を追加し、プレビューデプロイが本番ドメインを奪う問題を解消

## データ
- Cloudflare KV（binding `NOTICE`、1件運用）

## テスト
- `app/lib/notice.test.ts`（期間判定・TZ変換）
- `app/islands/NoticeBanner.test.tsx`（取得・表示）
- `app/routes/admin/index.test.tsx`（フォーム）
- lint / typecheck / test（191件）/ build すべてグリーン

## デプロイ状況
本番デプロイ・Access設定・動作確認まで完了済み（`/admin` は Access ログインへ302リダイレクトを確認）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)