### PR TITLE
feat: お知らせ管理画面にトップページへのリンクを追加

### DIFF
--- a/app/routes/admin/index.test.tsx
+++ b/app/routes/admin/index.test.tsx
@@ -14,6 +14,13 @@ describe('お知らせ管理画面', () => {
     expect(html).toContain('name="enabled"')
   })
 
+  it('トップページへのリンクがある', () => {
+    const html = render(AdminView({ notice: null, saved: false, kvAvailable: true, userEmail: null }))
+
+    expect(html).toContain('href="/"')
+    expect(html).toContain('トップページを見る')
+  })
+
   it('既存のお知らせが初期値として埋め込まれる', () => {
     const html = render(
       AdminView({

--- a/app/routes/admin/index.tsx
+++ b/app/routes/admin/index.tsx
@@ -13,8 +13,18 @@ type AdminViewProps = {
 export const AdminView: FC<AdminViewProps> = ({ notice, saved, kvAvailable, userEmail }) => (
   <main class="min-h-screen bg-gray-50 py-10">
     <div class="container mx-auto px-4 max-w-2xl">
-      <div class="flex items-baseline justify-between mb-6">
-        <h1 class="text-2xl font-bold text-gray-800">お知らせ管理</h1>
+      <div class="flex items-center justify-between mb-6 gap-4">
+        <div class="flex items-baseline gap-4">
+          <h1 class="text-2xl font-bold text-gray-800">お知らせ管理</h1>
+          <a
+            href="/"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-sm text-blue-700 hover:text-blue-900 underline whitespace-nowrap"
+          >
+            トップページを見る ↗
+          </a>
+        </div>
         {userEmail && <span class="text-sm text-gray-500">{userEmail}</span>}
       </div>
 


### PR DESCRIPTION
## 概要
お知らせ管理画面（`/admin`）のタイトル横に、トップページを別タブで開くリンク「トップページを見る ↗」を追加しました。

## 目的
お知らせを保存したあと、そのままトップページでバナーの表示を確認できるようにするため。別タブで開くので管理画面を開いたまま確認できます。

## テスト
- `app/routes/admin/index.test.tsx` にリンク存在の確認を追加
- lint / typecheck / test（192件）すべてグリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)